### PR TITLE
lol nevermind that breaks stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,4 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 # Build the app
 RUN npm run build
-
-
-# Production runner stage
-FROM node:${node_version} AS runner
-USER node
-WORKDIR /app
-
-COPY --from=builder --chown=node:node /app/.next/standalone /app
-
-ENTRYPOINT [ "node", "server.js" ]
+ENTRYPOINT [ "npm", "run", "start" ]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    output: 'standalone',
-
     // DOCKER: If you're developing using a Docker container, uncomment the following 
     // lines to enable hot-reloading. Hot-reloading also works with this configueration
     // when using Node locally, but changes show up faster without it.


### PR DESCRIPTION
The standalone production build would cause issues with fetching resources (see screenshot). This is not as elegant, but at least it actually works :)

![image](https://github.com/user-attachments/assets/fd163744-24d0-4fa6-8c1e-ac4cc467f529)