### PR TITLE
Fix GitHub action

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -9,6 +9,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set lowercase repository owner environment variable (funky workaround because Docker is dumb)
         run: |
           echo "OWNER_LOWERCASE=${OWNER,,}" >>${GITHUB_ENV}
@@ -28,5 +31,6 @@ jobs:
       - name: Build and push (client)
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           tags: ghcr.io/${{ env.OWNER_LOWERCASE }}/alexandria-client:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
 COPY . .
 
 # Disable NextJS telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Build the app
 RUN npm run build


### PR DESCRIPTION
.dockerignore doesn't work when using `docker/build-push-action` with a git context, since 'any file mutation in the steps that precede the build step will be ignored'

(See https://github.com/marketplace/actions/build-and-push-docker-images#git-context)