### PR TITLE
Hardcode API base URL in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ COPY . .
 # Disable NextJS telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Set the API base URL, hardcoded for now
+ENV NEXT_PUBLIC_API_BASE_URL=https://api.alexandria01.ewi.tudelft.nl/api/v2
+
+
 # Build the app
 RUN npm run build
 ENTRYPOINT [ "npm", "run", "start" ]


### PR DESCRIPTION
Because the only other option, replacing it at runtime, is extremely cursed (If you don't believe me, see https://github.com/osoc21/RoadBase/blob/master/frontend/Dockerfile#L23)